### PR TITLE
Fix example linting command

### DIFF
--- a/docs/tools/eslint.md
+++ b/docs/tools/eslint.md
@@ -47,7 +47,7 @@ In your `package.json` add to `scripts`:
 ```json
 {
   "scripts": {
-    "lint": "eslint src/**"
+    "lint": "eslint \"src/**\""
   }
 }
 ```


### PR DESCRIPTION
Otherwise an error will be thrown from eslint: `No files matching the pattern "src/<directory>" were found.`